### PR TITLE
use stable jenkins version

### DIFF
--- a/tasks/repo.debian.yml
+++ b/tasks/repo.debian.yml
@@ -7,7 +7,7 @@
   apt: name=python-pycurl state=installed
 
 - name: Add jenkins apt-key
-  apt_key: data="{{ lookup('file', 'jenkins-ci.org.key') }}" state=present
+  apt_key: url='{{ jenkins.deb.apt_key }}' state=present
 
 - name: Add Jenkins repository
   apt_repository: repo='{{ jenkins.deb.repo }}' state=present update_cache=yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,8 @@ jenkins_dest: /opt/jenkins
 jenkins_lib: /var/lib/jenkins
 jenkins:
   deb:
-    repo: 'deb http://pkg.jenkins-ci.org/debian binary/' # Jenkins repository
+    repo: 'deb http://pkg.jenkins-ci.org/debian-stable binary/' # Jenkins repository
+    apt_key: 'http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key' # Jenkins repository apt-key
     dependencies: # Jenkins dependencies
       - 'openjdk-7-jre'
       - 'openjdk-7-jdk'


### PR DESCRIPTION
- Pulls jenkins version from the stable repository rather than the weekly build repo.
- Abstracted the jenkins repo apt-key into the vars yml file for consistency.